### PR TITLE
Declare the junixsocket-core dependency as pom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     ).onEach {
       implementation(it) {
         version {
-          strictly("[1.6,1.7)")
+          strictly("[1.4,1.7)")
           prefer("1.6.21")
         }
       }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,9 @@ dependencies {
   api("com.squareup.okhttp3:okhttp:4.9.3")
   implementation("com.squareup.okio:okio:3.1.0")
 
-  implementation("com.kohlschutter.junixsocket:junixsocket-core:2.4.0")
+  implementation("com.kohlschutter.junixsocket:junixsocket-core:2.4.0@pom") {
+    isTransitive = true
+  }
   implementation("com.kohlschutter.junixsocket:junixsocket-common:2.4.0")
 
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")


### PR DESCRIPTION
The artifact type has changed since junixsocket-core:2.4.0, see https://github.com/kohlschutter/junixsocket/commit/47795ecb506b6820d5855e7666984dc6d4581043

Relates to https://github.com/gesellix/docker-client/issues/245
