### PR TITLE
Require at least junixsocket 2.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     ).onEach {
       implementation(it) {
         version {
-          strictly("[2.3,3)")
+          strictly("[2.4,3)")
           prefer("2.4.0")
         }
       }


### PR DESCRIPTION
Require at least junixsocket 2.4 to be consistent with the @pom dependency type.

Relates to #88