### PR TITLE
Add macos-15-intel as replacement for macos-13

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,6 +22,7 @@ jobs:
           - ubuntu-latest
         #          - windows-latest
         #          - macos-latest
+        #          - macos-15-intel
         java:
           - '21'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - windows-latest
           # pinned to macos-13 due to https://github.com/actions/runner-images/issues/9254
           - macos-13
+          - macos-15-intel
         java:
           - '21'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
       - name: Install Docker on macOS
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-15-intel'
         uses: douglascamata/setup-docker-macos-action@v1.0.0
       - name: Prepare Named Pipe integration test on Windows
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/9254
See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
